### PR TITLE
feat(首页): 重构文章展示逻辑并添加菜单tab功能

### DIFF
--- a/src/apis/admin/index.ts
+++ b/src/apis/admin/index.ts
@@ -32,6 +32,10 @@ export const deletePage = (id: number, config?: AxiosRequestConfig) => {
 export const searchMenu = (params?: Menu, config?: AxiosRequestConfig) => {
   return request.get<ResultSuccess<Menu[]>>('/tech/menu/tree', params, config);
 };
+// 获取tab下的菜单
+export const searchMenuByTab = (params?: { tabId: number }, config?: AxiosRequestConfig) => {
+  return request.get<ResultSuccess<Menu[]>>(`/tech/menu/list`, params, config);
+};
 // 删除菜单
 export const deleteMenu = (id: number, config?: AxiosRequestConfig) => {
   return request.delete<ResultSuccess<{ code: number; message: string }>>(

--- a/src/components/CTextRoll/index.vue
+++ b/src/components/CTextRoll/index.vue
@@ -58,7 +58,6 @@ const setScrollAnimation = () => {
     case 'up':
       contentStyle.value['--animation-end'] = `-${contentHeight}px`;
       scrollLength = contentHeight + textScrollHeight;
-      console.log('🚀 ~ setScrollAnimation ~ scrollLength:', scrollLength);
       time = scrollLength / props.speed;
       contentStyle.value.animation = `up-scroll linear ${time}s infinite`;
       break;

--- a/src/views/Home/Home.vue
+++ b/src/views/Home/Home.vue
@@ -24,7 +24,7 @@
       <ArticleContent
         v-if="isHomePage"
         :carousel-articles="articleList.first"
-        :right-articles="articleList.second"
+        :mebuTabs="firstMenuTabs"
       />
       <CenterSplit
         v-if="isHomePage"
@@ -35,7 +35,7 @@
       <ArticleContent
         v-if="isHomePage"
         :carousel-articles="articleList.third"
-        :right-articles="articleList.fourth"
+        :mebuTabs="secondMenuTabs"
         :is-row-reverse="!isMobile"
       />
       <RouterView v-if="!isHomePage" />
@@ -58,10 +58,9 @@ import HomeBottom from './components/HomeBottom.vue';
 import CenterSplit from './components/CenterSplit.vue';
 import FriendLink from './components/friendLink.vue';
 import type { Menu, Page } from '@/types';
-import { searchMenu, searchResource, searchPage } from '@/apis';
+import { searchMenu, searchResource, searchPage, searchMenuByTab } from '@/apis';
 import NavMenu from './components/NavMenu.vue';
 import type { GlobalThemeOverrides } from 'naive-ui';
-import dayjs from 'dayjs';
 const themeOverrides: GlobalThemeOverrides = {
   Input: {
     borderHover: '1px solid #1e80ff',
@@ -137,15 +136,13 @@ const queryResources = () => {
 
 const articleList = ref<{
   first: Page[];
-  second: Page[];
   third: Page[];
-  fourth: Page[];
 }>({
   first: [],
-  second: [],
   third: [],
-  fourth: [],
 });
+const firstMenuTabs = ref<Menu[]>([]);
+const secondMenuTabs = ref<Menu[]>([]);
 const getArticles = () => {
   const params = {
     page: 1,
@@ -155,25 +152,30 @@ const getArticles = () => {
   searchPage(params).then((res) => {
     if (res.data) {
       const first = res.data.records.filter((it) => it.showType === 1);
-      const second = res.data.records.filter((it) => it.showType === 2);
       const third = res.data.records.filter((it) => it.showType === 3);
-      const fourth = res.data.records.filter((it) => it.showType === 4);
       articleList.value.first = first;
-      articleList.value.second = [...first, ...second].sort(
-        (a, b) => +dayjs(b.publishTime) - +dayjs(a.publishTime),
-      );
       articleList.value.third = third;
-      articleList.value.fourth = [...third, ...fourth].sort(
-        (a, b) => +dayjs(b.publishTime) - +dayjs(a.publishTime),
-      );
+    }
+  });
+};
+const getMenuByTab = () => {
+  searchMenuByTab({ tabId: 1 }).then(async (res) => {
+    if (res.code === 0) {
+      firstMenuTabs.value = res.data as Menu[];
+    }
+  });
+  searchMenuByTab({ tabId: 2 }).then(async (res) => {
+    if (res.code === 0) {
+      secondMenuTabs.value = res.data as Menu[];
     }
   });
 };
 
-onBeforeMount(async () => {
+onBeforeMount(() => {
   getArticles();
   queryResources();
-  await searchMenuList();
+  getMenuByTab();
+  searchMenuList();
 });
 </script>
 


### PR DESCRIPTION
移除调试日志并重构首页文章展示组件，使用菜单tab代替原有文章列表
添加根据tab获取菜单的API接口
实现菜单tab切换时加载对应文章的功能
添加空状态提示